### PR TITLE
[docker] Ref #12 Create docker dev image with Python tools pre-installed

### DIFF
--- a/docker/images/dev-cli/Dockerfile
+++ b/docker/images/dev-cli/Dockerfile
@@ -1,0 +1,13 @@
+# Creates an image for skycoin development
+FROM skycoin/skycoindev-cli:develop
+
+# Install python software
+
+RUN set -ex; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+    python2.7-dev \
+    python-pip \
+    tox ;\
+    apt-get clean; \
+    pip install --upgrade pip


### PR DESCRIPTION
Fixes #12 

Changes:

Create docker dev image with Python tools pre-installed based on skycoindev-cli with name skycoindev-cli:py2
Does this change need to mentioned in CHANGELOG.md?
No