### PR TITLE
[pyskycoin] refs #28. Call rule build-libc in skycoin Makefile using -C option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ configure:
 	mkdir -p $(BUILDLIBC_DIR) $(BIN_DIR) $(INCLUDE_DIR)
 
 $(BUILDLIBC_DIR)/libskycoin.a: $(LIB_FILES) $(SRC_FILES)
-	cd $(SKYCOIN_DIR) && GOPATH="$(GOPATH_DIR)" make build-libc-static
+	GOPATH="$(GOPATH_DIR)" make -C $(SKYCOIN_DIR) build-libc-static
 	echo "After building libskycoin"
 	ls $(BUILDLIBC_DIR)
 	rm -Rf swig/include/libskycoin.h


### PR DESCRIPTION
Fixes #28

Changes:
- When calling Makefile rule in a different Makefile use -C option.
